### PR TITLE
fix some x64 typos

### DIFF
--- a/amoco/arch/x64/asm.py
+++ b/amoco/arch/x64/asm.py
@@ -184,7 +184,7 @@ def i_POPFQ(i,fmap):
 
 #------------------------------------------------------------------------------
 def _cmps_(i,fmap,l):
-  counter,d,s = ecx,edi,esi if i.misc['adrsz'] else rcx,rdi,rsi
+  counter,d,s = (ecx,edi,esi) if i.misc['adrsz'] else (rcx,rdi,rsi)
   dst = fmap(mem(d,l*8))
   src = fmap(mem(s,l*8))
   x, carry, overflow = SubWithBorrow(dst,src)
@@ -557,7 +557,8 @@ def i_SBB(i,fmap):
   op2 = fmap(i.operands[1])
   fmap[rip] = fmap[rip]+i.length
   a=fmap(op1)
-  x,carry,overflow = SubWithBorrow(a,op2,fmap(cf))
+  c=fmap(cf)
+  x,carry,overflow = SubWithBorrow(a,op2,c)
   fmap[pf]  = parity8(x[0:8])
   fmap[af]  = halfborrow(a,op2,c)
   fmap[zf]  = x==0
@@ -897,7 +898,7 @@ def i_IMUL(i,fmap):
 def i_MUL(i,fmap):
   fmap[rip] = fmap[rip]+i.length
   src = fmap(i.operands[0])
-  m,d = {8:(al,ah), 16:(ax,dx), 32:(eax,edx)}[src.size]
+  m,d = {8:(al,ah), 16:(ax,dx), 32:(eax,edx), 64:(rax,rdx)}[src.size]
   r = m**src
   lo = r[0:src.size]
   hi = r[src.size:r.size]

--- a/amoco/arch/x64/env.py
+++ b/amoco/arch/x64/env.py
@@ -61,7 +61,7 @@ dh = slc(rdx,8,8,'dh')
 
 cf = slc(rflags,0,1,'cf')   # carry/borrow flag
 pf = slc(rflags,2,1,'pf')   # parity flag
-af = slc(eflags,4,1,'pf')   # aux carry flag
+af = slc(eflags,4,1,'af')   # aux carry flag
 zf = slc(rflags,6,1,'zf')   # zero flag
 sf = slc(rflags,7,1,'sf')   # sign flag
 df = slc(rflags,10,1,'df')  # direction flag

--- a/amoco/arch/x64/env.py
+++ b/amoco/arch/x64/env.py
@@ -20,6 +20,7 @@ rsi    = reg('rsi',64)     # ptr to data in segment pointed by DS; src ptr for s
 rdi    = reg('rdi',64)     # ptr to data in segment pointed by ES; dst ptr for strings
 rip    = reg('rip',64)     # instruction pointer in 64 bit mode
 rflags = reg('rflags',64)
+eflags = slc(rflags, 16, 32,'eflags')
 
 
 # 32bits registers :
@@ -60,6 +61,7 @@ dh = slc(rdx,8,8,'dh')
 
 cf = slc(rflags,0,1,'cf')   # carry/borrow flag
 pf = slc(rflags,2,1,'pf')   # parity flag
+af = slc(eflags,4,1,'pf')   # aux carry flag
 zf = slc(rflags,6,1,'zf')   # zero flag
 sf = slc(rflags,7,1,'sf')   # sign flag
 df = slc(rflags,10,1,'df')  # direction flag


### PR DESCRIPTION
I had to fix the following typos to be able to use the x64 mode.
