### PR TITLE
Cast tst operands to int before passing to z3

### DIFF
--- a/amoco/cas/smt.py
+++ b/amoco/cas/smt.py
@@ -107,10 +107,18 @@ def cast_z3_bool(x,solver=None):
         b = (b==z3.BitVecVal(1,1))
     return b
 
+def cast_z3_int(x,solver=None):
+    b = x.to_smtlib(solver)
+    if z3.is_bool(b):
+        b = z3.If(b, z3.BitVecVal(1,1), z3.BitVecVal(0,1))
+    return b
+
 def tst_to_z3(e,solver=None):
     e.simplify()
     z3t = cast_z3_bool(e.tst,solver)
-    return z3.If( z3t , e.l.to_smtlib(solver), e.r.to_smtlib(solver))
+    l = cast_z3_int(e.l,solver)
+    r = cast_z3_int(e.r,solver)
+    return z3.If(z3t, l, r)
 
 def tst_verify(e,env):
     t = e.tst.eval(env).simplify()


### PR DESCRIPTION
I encountered the opposite problem of integers interpreted as booleans: here, registers flags are defined as equations but z3 expects an integer.
