### PR TITLE
Convert block types to subclass list.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,9 +167,9 @@ Lets proceed with getting some basic blocks...
  0x8048396  56                             push        esi
  0x8048397  68fd840408                     push        #main
  0x804839c  e8cfffffff                     call        *0x8048370
- >>> b.instr
+ >>> list(b)
  [<amoco.arch.x86.spec_ia32 [0x8048380]  XOR ( length=2 type=1 )>, <amoco.arch.x86.spec_ia32 [0x8048382]  POP ( length=1 type=1 )>, <amoco.arch.x86.spec_ia32 [0x8048383]  MOV ( length=2 type=1 )>, <amoco.arch.x86.spec_ia32 [0x8048385]  AND ( length=3 type=1 )>, <amoco.arch.x86.spec_ia32 [0x8048388]  PUSH ( length=1 type=1 )>, <amoco.arch.x86.spec_ia32 [0x8048389]  PUSH ( length=1 type=1 )>, <amoco.arch.x86.spec_ia32 [0x804838a]  PUSH ( length=1 type=1 )>, <amoco.arch.x86.spec_ia32 [0x804838b]  PUSH ( length=5 type=1 )>, <amoco.arch.x86.spec_ia32 [0x8048390]  PUSH ( length=5 type=1 )>, <amoco.arch.x86.spec_ia32 [0x8048395]  PUSH ( length=1 type=1 )>, <amoco.arch.x86.spec_ia32 [0x8048396]  PUSH ( length=1 type=1 )>, <amoco.arch.x86.spec_ia32 [0x8048397]  PUSH ( length=5 type=1 )>, <amoco.arch.x86.spec_ia32 [0x804839c]  CALL ( length=5 type=2 )>]
- >>> i = b.instr[-1]
+ >>> i = b[-1]
  >>> i
  <amoco.arch.x86.spec_ia32 [0x804839c]  CALL ( length=5 type=2 )>
  >>> print i

--- a/amoco/code.py
+++ b/amoco/code.py
@@ -74,22 +74,6 @@ class block(list):
         self._name = name
     name = property(getname,setname)
 
-    def __getitem__(self,i):
-        sta,sto,stp = i.indices(self.length)
-        assert stp==1
-        pos = [0]
-        for i in self:
-            pos.append(pos[-1]+i.length)
-        try:
-            ista = pos.index(sta)
-            isto = pos.index(sto)
-        except ValueError:
-            logger.warning("can't slice block: indices must match instruction boudaries")
-            return None
-        I = self[ista:isto]
-        if len(I)>0:
-            return block(self[ista:isto])
-
     # cut the block at given address will remove instructions after this address,
     # which needs to be aligned with instructions boundaries. The effect is thus to
     # reduce the block size. The returned value is the number of instruction removed.

--- a/amoco/code.py
+++ b/amoco/code.py
@@ -14,14 +14,14 @@ logger = Log(__name__)
 #------------------------------------------------------------------------------
 # A block instance is a 'continuous' sequence of instructions.
 #------------------------------------------------------------------------------
-class block(object):
+class block(list):
     __slots__=['_map','instr','_name','misc','_helper']
 
     # the init of a block takes a list of instructions and creates a map of it:
-    def __init__(self, instrlist, name=None):
+    def __init__(self, instrlist=[], name=None):
+        super(block, self).__init__(instrlist)
         self._map  = None
         # base/offset need to be defined before code (used in setcode)
-        self.instr = instrlist
         self._name = name
         self.misc  = defaultdict(lambda :0)
         self._helper = None
@@ -29,7 +29,7 @@ class block(object):
     @property
     def map(self):
         if self._map is None:
-            self._map = mapper(self.instr)
+            self._map = mapper(self)
             self.helper(self._map)
         if self.misc['func']:
             return self.misc['func'].map
@@ -43,15 +43,15 @@ class block(object):
 
     @property
     def address(self):
-        return self.instr[0].address if len(self.instr)>0 else None
+        return self[0].address if len(self)>0 else None
 
     @property
     def length(self):
-        return sum([i.length for i in self.instr],0)
+        return sum([i.length for i in self],0)
 
     @property
     def support(self):
-        return (self.address,self.address+self.length) if len(self.instr)>0 else (None,None)
+        return (self.address,self.address+self.length) if len(self)>0 else (None,None)
 
     def getname(self):
         return str(self.address) if not self._name else self._name
@@ -63,7 +63,7 @@ class block(object):
         sta,sto,stp = i.indices(self.length)
         assert stp==1
         pos = [0]
-        for i in self.instr:
+        for i in self:
             pos.append(pos[-1]+i.length)
         try:
             ista = pos.index(sta)
@@ -71,42 +71,42 @@ class block(object):
         except ValueError:
             logger.warning("can't slice block: indices must match instruction boudaries")
             return None
-        I = self.instr[ista:isto]
+        I = self[ista:isto]
         if len(I)>0:
-            return block(self.instr[ista:isto])
+            return block(self[ista:isto])
 
     # cut the block at given address will remove instructions after this address,
     # which needs to be aligned with instructions boundaries. The effect is thus to
     # reduce the block size. The returned value is the number of instruction removed.
     def cut(self,address):
-        I = [i.address for i in self.instr]
+        I = [i.address for i in self]
         try:
             pos = I.index(address)
         except ValueError:
             logger.warning("invalid attempt to cut block %s at %s"%(self.name,address))
             return 0
         else:
-            self.instr = self.instr[:pos]
+            self = self[:pos]
             if self._map:
                 self._map.clear()
-                for i in self.instr:
+                for i in self:
                     i(self._map)
             # TODO: update misc annotations too
             return len(I)-pos
 
     def __str__(self):
         L = []
-        n = len(self.instr)
+        n = len(self)
         if conf.getboolean('block','header'):
             L.append('# --- block %s ---' % self.name)
         if conf.getboolean('block','bytecode'):
-            bcs = [ "'%s'"%(i.bytes.encode('hex')) for i in self.instr ]
+            bcs = [ "'%s'"%(i.bytes.encode('hex')) for i in self ]
             pad = conf.getint('block','padding') or 0
             maxlen = max(map(len,bcs))+pad
             bcs = [ s.ljust(maxlen) for s in bcs ]
         else:
             bcs = ['']*n
-        ins = [ ('{:<10}'.format(i.address),i.formatter(i)) for i in self.instr ]
+        ins = [ ('{:<10}'.format(i.address),i.formatter(i)) for i in self ]
         for j in range(n):
             L.append('%s %s %s'%(ins[j][0],bcs[j],ins[j][1]))
         return '\n'.join(L)
@@ -115,7 +115,7 @@ class block(object):
         return '<%s object (name=%s) at 0x%08x>'%(self.__class__.__name__,self.name,id(self))
 
     def raw(self):
-        return ''.join([i.bytes for i in self.instr])
+        return ''.join([i.bytes for i in self])
 
     def __cmp__(self,b):
         return cmp(self.raw(),b.raw())
@@ -127,7 +127,7 @@ class block(object):
         misc = defaultdict(lambda :None)
         misc.update(self.misc)
         if len(misc)==0:
-            for i in self.instr: misc.update(i.misc)
+            for i in self: misc.update(i.misc)
         s = [tag.sig(k) for k in misc]
         return '(%s)'%(''.join(s))
 
@@ -143,7 +143,6 @@ class func(block):
     def __init__(self, g=None, name=None):
         self._map = None
         self.cfg = g
-        self.instr = []
         # base/offset need to be defined before code (used in setcode)
         self._name = name
         self.misc  = defaultdict(lambda :0)

--- a/amoco/code.py
+++ b/amoco/code.py
@@ -15,6 +15,21 @@ logger = Log(__name__)
 # A block instance is a 'continuous' sequence of instructions.
 #------------------------------------------------------------------------------
 class block(list):
+    """
+    A block instance is a 'continuous' sequence of instructions.
+
+    Example usage:
+
+        .. code-block:: python
+
+            block  = amoco.code.block()
+
+            while address < len(bytes):
+              i = cpu.disassemble(bytes[address:], address=address)
+              address += i.length
+              block.append(i)
+    """
+
     __slots__=['_map','instr','_name','misc','_helper']
 
     # the init of a block takes a list of instructions and creates a map of it:

--- a/amoco/db.py
+++ b/amoco/db.py
@@ -52,17 +52,17 @@ class db_mapper(db_core):
         return m
 
 #------------------------------------------------------------------------------
-class db_block(db_core):
+class db_block(db_core, list):
 
     def __init__(self,b):
         self.name = b.name
         self.misc = dict(b.misc)
-        self.instr = [db_instruction(i) for i in b.instr]
+        self.extend(db_instruction(i) for i in b)
         self.map = db_mapper(b.map)
         self.view = str(b)
 
     def build(self,cpu):
-        instr = [i.build(cpu) for i in self.instr]
+        instr = [i.build(cpu) for i in self]
         b = block(instr)
         b.map = self.map.build()
         b.misc.update(self.misc)

--- a/amoco/system/linux_x64.py
+++ b/amoco/system/linux_x64.py
@@ -122,7 +122,7 @@ class ELF(CoreExec):
         return seq
 
     def blockhelper(self,block):
-        for i in self.seqhelper(block.instr):
+        for i in self.seqhelper(block):
             block.misc.update(i.misc)
         def _helper(block,m):
             # annotations based on block semantics:

--- a/amoco/system/linux_x86.py
+++ b/amoco/system/linux_x86.py
@@ -120,7 +120,7 @@ class ELF(CoreExec):
         return seq
 
     def blockhelper(self,block):
-        for i in self.seqhelper(block.instr):
+        for i in self.seqhelper(block):
             block.misc.update(i.misc)
         # delayed computation of block.map:
         def _helper(block,m):

--- a/amoco/system/pic18.py
+++ b/amoco/system/pic18.py
@@ -75,7 +75,7 @@ class PIC18(CoreExec):
         return seq
 
     def blockhelper(self,blk):
-        self.seqhelper(blk.instr)
+        self.seqhelper(blk)
         return blk
 
     def pic_seg_handler(self,env,seg,base_disp):

--- a/amoco/system/win32.py
+++ b/amoco/system/win32.py
@@ -114,7 +114,7 @@ class PE(CoreExec):
         return seq
 
     def blockhelper(self,block):
-        for i in self.seqhelper(block.instr):
+        for i in self.seqhelper(block):
             block.misc.update(i.misc)
         def _helper(block,m):
             # update block.misc based on semantics:

--- a/amoco/system/win64.py
+++ b/amoco/system/win64.py
@@ -114,7 +114,7 @@ class PE(CoreExec):
         return seq
 
     def blockhelper(self,block):
-        for i in self.seqhelper(block.instr):
+        for i in self.seqhelper(block):
             block.misc.update(i.misc)
         # delayed computation of block.map:
         def _helper(block,m):


### PR DESCRIPTION
This removes the need to iterate over '.instr' and makes the this code pattern possible.

``` py
block  = amoco.code.block()
idx    = 0
while idx < len(bytes):
    ins = cpu.disassemble(bytes[idx:], address=address+idx)
    idx += ins.length
    block.append(ins)
```

I was unsure about the use of `.instr` in these cases, so I did not make the resplacements there:

```
amoco/arch/x86/parsers.py
114:            E = cls.instr.parseString(res,True)

amoco/cas/parser.py
52:    return p_expr.parseString(s,True)
58:            E = p_expr.parseString(res,True)

amoco/arch/sparc/parsers.py
117:            E = cls.instr.parseString(res,True)

amoco/arch/core.py
321:        ast = specdecode.parseString(self.format,True)
```
