### PR TITLE
Fix issue in op_to_z3

### DIFF
--- a/amoco/cas/smt.py
+++ b/amoco/cas/smt.py
@@ -156,7 +156,10 @@ def op_to_z3(e,solver=None):
         greatest = max(z3l.size(), z3r.size())
         z3l = z3.ZeroExt(greatest - z3l.size(), z3l)
         z3r = z3.ZeroExt(greatest - z3r.size(), z3r)
-    return op(z3l,z3r)
+    res = op(z3l,z3r)
+    if z3.is_bool(res):
+        res = _bool2bv1(res)
+    return res
 
 def uop_to_z3(e,solver=None):
     e.simplify()


### PR DESCRIPTION
In some cases, the result returned by `op_to_z3` would be a `Bool` expression instead of a `BitVec` expression; this can be triggered with the code below for example:

``` python
import amoco
import amoco.system.raw
import amoco.system.core
import amoco.cas.smt
import amoco.arch.x86.cpu_x86 as cpu

def sym_exec_gadget_and_get_mapper(code, address_code = 0xdeadbeef):
    p = amoco.system.raw.RawExec(
        amoco.system.core.DataIO(code), cpu
    )
    blocks = list(amoco.lsweep(p).iterblocks())
    assert(len(blocks) > 0)
    mp = amoco.cas.mapper.mapper()
    for block in blocks:
        if block.instr[-1].mnemonic.lower() == 'call':
            p.cpu.i_RET(None, block.map)
        mp >>= block.map
    return mp

sym_exec_gadget_and_get_mapper('\x91Z\xba\\q\xf9\xd8Nz\xe0\xff#')[cpu.eflags].to_smtlib()
```

I've just added a bit of code to handle this case: if the returned expression is a `Bool`, then we convert it back to a `BitVec` expression via `_bool2bv1`.

Cheers!
