### PR TITLE
Suggestion: Always install blessed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
                         'crysp>=1.1',
                         'pyparsing',
                         'traitlets',
+                        'blessed',
                        ],
     entry_points={
         'console_scripts': [ 'amoco=amoco.ui.app:cli [app]' ],
@@ -65,7 +66,6 @@ setup(
                  'pygments',
                  'z3-solver',
                  'tqdm',
-                 'blessed',
                  'ccrawl>=1.2',
                  'PySide2'],
     },


### PR DESCRIPTION
I'm not certain about your contributions guidelines, but when I tried installing amoco: `pip install git+https://github.com/bdcht/amoco` and trying to import the library:

```python
import amoco
```

I was greeted with this: 
```python
Traceback (most recent call last):
  File "ape.py", line 2, in <module>
    import amoco
  File "/tmp/env/lib/python3.7/site-packages/amoco/__init__.py", line 1, in <module>
    from .main import *
  File "/tmp/env/lib/python3.7/site-packages/amoco/main.py", line 17, in <module>
    from amoco.system.core import read_program, load_program
  File "/tmp/env/lib/python3.7/site-packages/amoco/system/core.py", line 18, in <module>
    from amoco.ui.views import execView
  File "/tmp/env/lib/python3.7/site-packages/amoco/ui/views.py", line 15, in <module>
    from blessed import Terminal
ModuleNotFoundError: No module named 'blessed'
```

Which is not a big deal (can just install blessed with pip and its gone), but with this small change to the setup we can avoid this in the future. Also, if you allow me to make a suggestions, I would very much like to see this project in pypi so that in the future we can perform `pip install amoco` as the name is not used yet. 