### PR TITLE
chore: update to use SPDX license (GPL-2.0-or-later)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,8 @@ Licence
 
 Please see `LICENSE`_.
 
+SPDX-License-Identifier: [GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later)
+
 
 Changelog
 =========

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+        'License :: OSI Approved :: GNU General Public License v2 or later (GPL-2.0-or-later)',
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Security",


### PR DESCRIPTION
Update to use SPDX identifier (GPL-2.0 is deprecated license identifier, so update to use `GPL-2.0-or-later`)

cc @bdcht 